### PR TITLE
Fixing JavaDoc

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -20,9 +20,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/*
-* Servlet that stubs response from /data URL. Expected response is of type String.
-*/
+/**
+ * Servlet that stubs response from /data URL. Expected response is of type String.
+ */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 


### PR DESCRIPTION
Fixing JavaDoc format for DataServlet.java file. 

Pressed merge too soon on previous PR.