### PR TITLE
Feature/authentication-hide form

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
@@ -15,11 +15,7 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
-import com.google.appengine.repackaged.com.google.api.client.json.Json;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
@@ -35,8 +35,9 @@ public class AuthStatusServlet extends HttpServlet {
    * Will return the authentication status of the current user.
    * @param request HTTP request received from the client. Should contain no params.
    * @param response HTTP Response to send back to the user. Should contain JSON object with
-   *     two parameters: logged-in and link, where logged-in is true/false and link is either
-   *     a link to login if the user isn't logged in, or logout link if user is logged in.
+   *     two parameters: loggedIn and changeAuthenticationUrl, where loggedIn is true/false
+   *     and changeAuthenticationUrl is either a link to login if the user isn't logged in,
+   *     or logout link if user is logged in.
    * @throws IOException if there is an issue with getWriter() while processing the request.
    */
   @Override
@@ -45,15 +46,15 @@ public class AuthStatusServlet extends HttpServlet {
     boolean isLoggedIn = userService.isUserLoggedIn();
 
     JsonObject authInfo = new JsonObject();
-    authInfo.addProperty("logged-in", isLoggedIn);
+    authInfo.addProperty("loggedIn", isLoggedIn);
 
     // If the user is logged in, add a logout link to response (and vice versa)
     if (isLoggedIn) {
       String logoutUrl = userService.createLogoutURL("/index.html");
-      authInfo.addProperty("link", logoutUrl);
+      authInfo.addProperty("changeAuthenticationUrl", logoutUrl);
     } else {
       String loginUrl = userService.createLoginURL("/index.html");
-      authInfo.addProperty("link", loginUrl);
+      authInfo.addProperty("changeAuthenticationUrl", loginUrl);
     }
 
     // Send JSON to client

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
@@ -15,6 +15,10 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.repackaged.com.google.api.client.json.Json;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -34,15 +38,31 @@ public class AuthStatusServlet extends HttpServlet {
   /**
    * Will return the authentication status of the current user.
    * @param request HTTP request received from the client. Should contain no params.
-   * @param response HTTP Response to send back to the user. Either contains "true" or "false"
+   * @param response HTTP Response to send back to the user. Should contain JSON object with
+   *     two parameters: logged-in and link, where logged-in is true/false and link is either
+   *     a link to login if the user isn't logged in, or logout link if user is logged in.
    * @throws IOException if there is an issue with getWriter() while processing the request.
    */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Get Authentication status from UserService. Add it to JSON object.
     boolean isLoggedIn = userService.isUserLoggedIn();
 
+    JsonObject authInfo = new JsonObject();
+    authInfo.addProperty("logged-in", isLoggedIn);
+
+    // If the user is logged in, add a logout link to response (and vice versa)
+    if (isLoggedIn) {
+      String logoutUrl = userService.createLogoutURL("/index.html");
+      authInfo.addProperty("link", logoutUrl);
+    } else {
+      String loginUrl = userService.createLoginURL("/index.html");
+      authInfo.addProperty("link", loginUrl);
+    }
+
+    // Send JSON to client
     response.setContentType("application/json");
-    response.getWriter().println(isLoggedIn);
+    response.getWriter().println(authInfo);
   }
 }
 

--- a/portfolio/src/main/webapp/css/abstracts/variables.css
+++ b/portfolio/src/main/webapp/css/abstracts/variables.css
@@ -43,6 +43,7 @@
   --shadow-dark: rgba(0, 0, 0, .65);
   --shadow-light: rgba(0, 0, 0, .35);
   --text-white: white;
+  --text-black: black;
 }
 
 /*

--- a/portfolio/src/main/webapp/css/base/typography.css
+++ b/portfolio/src/main/webapp/css/base/typography.css
@@ -83,11 +83,6 @@ h5 {
 
 .link-black {
   color: var(--text-black);
-}
-
-.blob-key-link {
   cursor: pointer;
-  color: var(--text-black);
-  text-decoration: underline solid var(--text-black);
 }
 

--- a/portfolio/src/main/webapp/css/base/typography.css
+++ b/portfolio/src/main/webapp/css/base/typography.css
@@ -84,3 +84,4 @@ h5 {
 .link-black {
   color: var(--text-black);
 }
+

--- a/portfolio/src/main/webapp/css/base/typography.css
+++ b/portfolio/src/main/webapp/css/base/typography.css
@@ -81,3 +81,6 @@ h5 {
   padding: 0 0 var(--heading-secondary-padding-btm) 0;
 }
 
+.link-black {
+  color: var(--text-black);
+}

--- a/portfolio/src/main/webapp/css/base/utility.css
+++ b/portfolio/src/main/webapp/css/base/utility.css
@@ -60,10 +60,18 @@
 }
 
 /*
-  Add underline to text link. Use border-bottom to improve text readability
+  Add white underline to text link. Use border-bottom to improve text readability
   (border bottom will not cut off text. text-decoration will cut through some letters).
 */
-.u-link-underline {
+.u-link-underline-white {
   border-bottom: var(--underline-size) solid var(--text-white);
+}
+
+/*
+  Add white underline to text link. Use border-bottom to improve text readability
+  (border bottom will not cut off text. text-decoration will cut through some letters).
+*/
+.u-link-underline-black {
+  border-bottom: var(--underline-size) solid var(--text-black);
 }
 

--- a/portfolio/src/main/webapp/css/sections/header.css
+++ b/portfolio/src/main/webapp/css/sections/header.css
@@ -46,3 +46,4 @@
 #comment-form {
   display: none;
 }
+

--- a/portfolio/src/main/webapp/css/sections/header.css
+++ b/portfolio/src/main/webapp/css/sections/header.css
@@ -38,3 +38,11 @@
   text-decoration: underline;
 }
 
+/*
+  By default, hide the form.
+  Form should only be visible if user is logged in
+  (handled in script.js)
+*/
+#comment-form {
+  display: none;
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -128,7 +128,7 @@
     <div>
       <!-- Will contain text to either prompt user to login, or offer a link to logout -->
       <p id="comment-form-authentication-prompt"></p>
-      <a class="link-black u-link-underline-black" href="#" id="comment-form-authentication-link">Authentication Link</a><br>
+      <a class="link-black u-link-underline-black" href="#" id="comment-form-authentication-link">Authentication Link</a>
 
       <!-- Form to submit a comment/contact information. No required fields for now. -->
       <form id="comment-form" action="/data" method="POST">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -127,8 +127,14 @@
     <!-- Form to submit a comment/contact information. No required fields for now. -->
     <div>
       <!-- Will contain text to either prompt user to login, or offer a link to logout -->
-      <p id="comment-form-authentication-prompt"></p>
-      <a class="link-black u-link-underline-black" href="#" id="comment-form-authentication-link">Authentication Link</a>
+      <div hidden id="logIn">
+        <p id="logInPrompt">To simplify form entry, and to verify your identity, please log in.</p>
+        <a class="link-black u-link-underline-black" href="#" id="logInLink">Log In with Google</a>
+      </div>
+      <div hidden id="logOut">
+        <p id="logOutPrompt">All done? Log out whenever you'd like</p>
+        <a class="link-black u-link-underline-black" href="#" id="logOutLink">Log Out of Google Account</a>
+      </div>
 
       <!-- Form to submit a comment/contact information. No required fields for now. -->
       <form id="comment-form" action="/data" method="POST">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -84,7 +84,7 @@
               </div>
               <div class="heading-secondary">
                 <p class="text-md">p: (519) 984-2619
-                <p class="text-md">e: <a class="u-link-underline" href="mailto:austinteshuba@gmail.com" target="_blank">austinteshuba@gmail.com</a>
+                <p class="text-md">e: <a class="u-link-underline-white" href="mailto:austinteshuba@gmail.com" target="_blank">austinteshuba@gmail.com</a>
               </div>
             </div>
           </div>
@@ -126,7 +126,12 @@
     <!-- TODO - style the forms (https://github.com/austinteshuba/GoogleSTEP2020/issues/24) -->
     <!-- Form to submit a comment/contact information. No required fields for now. -->
     <div>
-      <form action="/data" method="POST">
+      <!-- Will contain text to either prompt user to login, or offer a link to logout -->
+      <p id="comment-form-authentication-prompt"></p>
+      <a class="link-black u-link-underline-black" href="#" id="comment-form-authentication-link">Authentication Link</a><br>
+
+      <!-- Form to submit a comment/contact information. No required fields for now. -->
+      <form id="comment-form" action="/data" method="POST">
         <p>Introduce yourself!</p>
         <label for="firstName">First Name:</label><br>
         <input type="text" id="firstName" name="firstName"><br>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -20,11 +20,20 @@ const typewriterLetterDelayMs = 100;
 const typewriterWordDelayMs = 1000;
 const typewriterLoadDelayMs = 1000;
 
+<<<<<<< HEAD
+=======
+const logInPrompt =
+    'To simplify form entry, and to verify your identity, please log in.';
+const logOutPrompt = 'All done? Log out whenever you\'d like';
+
+// Start the typewriter effect when page loads
+>>>>>>> Hide form when logged out, show when logged in
 window.onload = function() {
   // Initialize the business card form
   // and retrieve all download URLs from the blobstore
   fetchBlobstoreUrl();
   getImageUrls();
+  checkAuthentication();
 
   // Start typewriter effect
   const passionSelector = document.getElementById('passions');
@@ -172,5 +181,69 @@ function getImageUrls() {
           container.innerText = imageUrls;
         }
       });
+}
+
+/**
+ * Gets the user's authentication status from the auth-status servlet
+ * and calls handleAuthenticationStatus function to change form visibility
+ * accordingly
+ */
+function checkAuthentication() {
+  fetch('/auth-status')
+      .then((response) => response.json())
+      .then((authInfo) => {
+        console.log(authInfo['logged-in']);
+        // Get the authentication status as boolean and auth link as string
+        const loggedIn = authInfo['logged-in'];
+        const authLink = authInfo['link'];
+
+        // Begin changes to the DOM depending on the authentication status
+        handleAuthenticationStatus(loggedIn, authLink);
+      });
+}
+
+/**
+ * Shows or hides the HTML form depending on the user's authentication status
+ * @param {boolean} visible
+ */
+function changeFormVisibility(visible) {
+  const form = document.getElementById('comment-form');
+
+  if (visible) {
+    form.style.display = 'block';
+  } else {
+    form.style.display = 'none';
+  }
+}
+
+/**
+ * Updates the HTML elements to prompt the user to log in or log out,
+ * with the correct link to do so below the text. Hides the comment
+ * form if logged out, shows it if logged in.
+ * @param {boolean} loggedIn true if user is logged in, false otherwise
+ * @param {string} authLink link to either log in or log out, as needed.
+ */
+function handleAuthenticationStatus(loggedIn, authLink) {
+  // Show the comments form if logged in, hide if logged out.
+  changeFormVisibility(loggedIn);
+
+  // Get the HTML elements
+  const authPromptElement =
+      document.getElementById('comment-form-authentication-prompt');
+
+  const authLinkElement =
+      document.getElementById('comment-form-authentication-link');
+
+  // If logged in, prompt user with link to log out.
+  // If logged out, prompt user to log in.
+  if (loggedIn) {
+    authPromptElement.innerText = logOutPrompt;
+    authLinkElement.innerHTML = 'Log Out of Google Account';
+  } else {
+    authPromptElement.innerText = logInPrompt;
+    authLinkElement.innerHTML = 'Log In with Google';
+  }
+
+  authLinkElement.href = authLink;
 }
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -192,7 +192,6 @@ function checkAuthentication() {
   fetch('/auth-status')
       .then((response) => response.json())
       .then((authInfo) => {
-        console.log(authInfo['logged-in']);
         // Get the authentication status as boolean and auth link as string
         const loggedIn = authInfo['logged-in'];
         const authLink = authInfo['link'];

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -20,14 +20,7 @@ const typewriterLetterDelayMs = 100;
 const typewriterWordDelayMs = 1000;
 const typewriterLoadDelayMs = 1000;
 
-<<<<<<< HEAD
-=======
-const logInPrompt =
-    'To simplify form entry, and to verify your identity, please log in.';
-const logOutPrompt = 'All done? Log out whenever you\'d like';
-
 // Start the typewriter effect when page loads
->>>>>>> Hide form when logged out, show when logged in
 window.onload = function() {
   // Initialize the business card form
   // and retrieve all download URLs from the blobstore
@@ -193,8 +186,8 @@ function checkAuthentication() {
       .then((response) => response.json())
       .then((authInfo) => {
         // Get the authentication status as boolean and auth link as string
-        const loggedIn = authInfo['logged-in'];
-        const authLink = authInfo['link'];
+        const loggedIn = authInfo['loggedIn'];
+        const authLink = authInfo['changeAuthenticationUrl'];
 
         // Begin changes to the DOM depending on the authentication status
         initializeFormState(loggedIn, authLink);
@@ -209,27 +202,29 @@ function checkAuthentication() {
  * @param {string} authLink link to either log in or log out, as needed.
  */
 function initializeFormState(loggedIn, authLink) {
-  // Get the HTML elements
-  const authPromptElement =
-      document.getElementById('comment-form-authentication-prompt');
-
-  const authLinkElement =
-      document.getElementById('comment-form-authentication-link');
-
   const form = document.getElementById('comment-form');
+
+  const logInContainer = document.getElementById('logIn');
+  const logOutContainer = document.getElementById('logOut');
+  const logInLink = document.getElementById('logInLink');
+  const logOutLink = document.getElementById('logOutLink');
 
   // If logged in, prompt user with link to log out and show form
   // If logged out, prompt user to log in and hide form
   if (loggedIn) {
-    authPromptElement.innerText = logOutPrompt;
-    authLinkElement.innerHTML = 'Log Out of Google Account';
+    logOutLink.href = authLink;
+    logInLink.href = '#';
+    logOutContainer.removeAttribute('hidden');
+    logInContainer.setAttribute('hidden', '');
+
     form.style.display = 'block';
   } else {
-    authPromptElement.innerText = logInPrompt;
-    authLinkElement.innerHTML = 'Log In with Google';
+    logInLink.href = authLink;
+    logOutLink.href = '#';
+    logInContainer.removeAttribute('hidden');
+    logOutContainer.setAttribute('hidden', '');
+
     form.style.display = 'none';
   }
-
-  authLinkElement.href = authLink;
 }
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -197,22 +197,8 @@ function checkAuthentication() {
         const authLink = authInfo['link'];
 
         // Begin changes to the DOM depending on the authentication status
-        handleAuthenticationStatus(loggedIn, authLink);
+        initializeFormState(loggedIn, authLink);
       });
-}
-
-/**
- * Shows or hides the HTML form depending on the user's authentication status
- * @param {boolean} visible
- */
-function changeFormVisibility(visible) {
-  const form = document.getElementById('comment-form');
-
-  if (visible) {
-    form.style.display = 'block';
-  } else {
-    form.style.display = 'none';
-  }
 }
 
 /**
@@ -222,10 +208,7 @@ function changeFormVisibility(visible) {
  * @param {boolean} loggedIn true if user is logged in, false otherwise
  * @param {string} authLink link to either log in or log out, as needed.
  */
-function handleAuthenticationStatus(loggedIn, authLink) {
-  // Show the comments form if logged in, hide if logged out.
-  changeFormVisibility(loggedIn);
-
+function initializeFormState(loggedIn, authLink) {
   // Get the HTML elements
   const authPromptElement =
       document.getElementById('comment-form-authentication-prompt');
@@ -233,14 +216,18 @@ function handleAuthenticationStatus(loggedIn, authLink) {
   const authLinkElement =
       document.getElementById('comment-form-authentication-link');
 
-  // If logged in, prompt user with link to log out.
-  // If logged out, prompt user to log in.
+  const form = document.getElementById('comment-form');
+
+  // If logged in, prompt user with link to log out and show form
+  // If logged out, prompt user to log in and hide form
   if (loggedIn) {
     authPromptElement.innerText = logOutPrompt;
     authLinkElement.innerHTML = 'Log Out of Google Account';
+    form.style.display = 'block';
   } else {
     authPromptElement.innerText = logInPrompt;
     authLinkElement.innerHTML = 'Log In with Google';
+    form.style.display = 'none';
   }
 
   authLinkElement.href = authLink;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -20,7 +20,6 @@ const typewriterLetterDelayMs = 100;
 const typewriterWordDelayMs = 1000;
 const typewriterLoadDelayMs = 1000;
 
-// Start the typewriter effect when page loads
 window.onload = function() {
   // Initialize the business card form
   // and retrieve all download URLs from the blobstore

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -180,7 +180,7 @@ function getBlobKeys() {
           blobKeyLink.innerText = blobKey;
           blobKeyLink.href = '/serve-image?blobKey=' + blobKey;
           blobKeyLink.target = '_blank';
-          blobKeyLink.className = 'blob-key-link';
+          blobKeyLink.className = 'link-black u-link-underline-black';
 
           listElement.appendChild(blobKeyLink);
           blobKeyList.appendChild(listElement);


### PR DESCRIPTION
Add functionality that will get the user's current authentication status and hide the form if the user is not logged in / show the form if the user is logged in. 

In both cases, a link appears on the homepage to either prompt the user to log in or allow them to log out. 

Log in Prompt (form hidden):
![Screenshot 2020-06-11 at 4 29 41 PM](https://user-images.githubusercontent.com/22511147/84436182-02320a00-ac01-11ea-9aeb-c18f34b1d095.png)

Logging In: 
![Screenshot 2020-06-11 at 4 29 45 PM](https://user-images.githubusercontent.com/22511147/84436237-170e9d80-ac01-11ea-9702-bc9fc574323b.png)

Log out prompt (form visible): 
![Screenshot 2020-06-11 at 4 30 18 PM](https://user-images.githubusercontent.com/22511147/84436293-2f7eb800-ac01-11ea-8cc0-dd0e1058c3da.png)


There is a small amount of CSS work here, but the forms are far from styled. Styling will come later as mentioned in issue #24. Styling is only to make the link black in the form, while keeping the styled header link white (without this CSS, the link would be white and therefore invisible on the white background).