### PR TITLE
Refactor to use hidden attribute where possible

### DIFF
--- a/portfolio/src/main/webapp/css/sections/header.css
+++ b/portfolio/src/main/webapp/css/sections/header.css
@@ -38,12 +38,4 @@
   text-decoration: underline;
 }
 
-/*
-  By default, hide the form.
-  Form should only be visible if user is logged in
-  (handled in script.js)
-*/
-#comment-form {
-  display: none;
-}
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -101,7 +101,7 @@
     </div>
 
     <!-- Container to display comments from server. Should be removed for prod version. -->
-    <div id="comments-container">
+    <div hidden id="comments-container">
       <!-- Form controls how many comments are displayed -->
       <!-- Return false is needed so form doesn't submit its own HTTP request. -->
       <form onsubmit="getData(); return false;">
@@ -141,7 +141,7 @@
       </div>
 
       <!-- Form to submit a comment/contact information. No required fields for now. -->
-      <form id="comment-form" action="/data" method="POST">
+      <form hidden id="comment-form" action="/data" method="POST">
         <p>Introduce yourself!</p>
         <label for="firstName">First Name:</label><br>
         <input type="text" id="firstName" name="firstName"><br>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -274,7 +274,6 @@ function initializeFormState(loggedIn, authLink) {
     logOutContainer.removeAttribute('hidden');
     logInContainer.setAttribute('hidden', '');
 
-    // form.style.display = 'block';
     form.removeAttribute('hidden');
   } else {
     logInLink.href = authLink;
@@ -282,7 +281,6 @@ function initializeFormState(loggedIn, authLink) {
     logInContainer.removeAttribute('hidden');
     logOutContainer.setAttribute('hidden', '');
 
-    // form.style.display = 'none';
     form.setAttribute('hidden', '');
   }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -274,14 +274,16 @@ function initializeFormState(loggedIn, authLink) {
     logOutContainer.removeAttribute('hidden');
     logInContainer.setAttribute('hidden', '');
 
-    form.style.display = 'block';
+    // form.style.display = 'block';
+    form.removeAttribute('hidden');
   } else {
     logInLink.href = authLink;
     logOutLink.href = '#';
     logInContainer.removeAttribute('hidden');
     logOutContainer.setAttribute('hidden', '');
 
-    form.style.display = 'none';
+    // form.style.display = 'none';
+    form.setAttribute('hidden', '');
   }
 }
 


### PR DESCRIPTION
Solves issue #36 

Uses the hidden element to hide/show the comments form and comments container. This is a less error-prone and more understandable implementation.